### PR TITLE
feat: remove convention to prevent rendering with empty tag name

### DIFF
--- a/Classes/DataProviding/Traits/RenderSubComponent.php
+++ b/Classes/DataProviding/Traits/RenderSubComponent.php
@@ -29,10 +29,6 @@ trait RenderSubComponent
             return null;
         }
 
-        if (!$componentRenderingData->isRenderable()) {
-            return null;
-        }
-
         $properties = $componentRenderingData->getTagProperties();
         if ($slot !== null) {
             $properties['slot'] = $slot;

--- a/Classes/Dto/ComponentRenderingData.php
+++ b/Classes/Dto/ComponentRenderingData.php
@@ -89,13 +89,8 @@ class ComponentRenderingData
         return $this->tagName;
     }
 
-    public function setTagName(?string $tagName): void
+    public function setTagName(string $tagName): void
     {
         $this->tagName = $tagName;
-    }
-
-    public function isRenderable(): bool
-    {
-        return $this->tagName !== null;
     }
 }

--- a/Classes/Dto/Events/ComponentWillBeRendered.php
+++ b/Classes/Dto/Events/ComponentWillBeRendered.php
@@ -7,6 +7,11 @@ namespace Sinso\Webcomponents\Dto\Events;
 use Sinso\Webcomponents\Dto\ComponentRenderingData;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
+/**
+ * Event is triggered after the component data has been provided and before the component is rendered.
+ * Listeners can modify the component rendering data.
+ * Listeners can throw an \Sinso\Webcomponents\DataProviding\AssertionFailedException to stop the rendering process.
+ */
 class ComponentWillBeRendered
 {
     public function __construct(

--- a/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Classes/ViewHelpers/RenderViewHelper.php
@@ -50,10 +50,6 @@ class RenderViewHelper extends AbstractViewHelper
         $eventDispatcher = GeneralUtility::makeInstance(EventDispatcher::class);
         $eventDispatcher->dispatch($event);
 
-        if (!$componentRenderingData->isRenderable()) {
-            return '';
-        }
-
         $tagName = $componentRenderingData->getTagName();
         $content = $componentRenderingData->getTagContent();
         $properties = $componentRenderingData->getTagProperties();

--- a/README.md
+++ b/README.md
@@ -60,7 +60,41 @@ class MyContentElement implements ComponentInterface
 }
 ```
 
-Convention: When the tag name is not set, the web component will not be rendered at all.
+## Abort rendering
+
+The component classes can use the `\Sinso\Webcomponents\DataProviding\Traits\Assert` trait to abort rendering, for example if the record is not available:
+
+```php
+<?php
+
+namespace Acme\MyExt\Components;
+
+use Sinso\Webcomponents\DataProviding\ComponentInterface;
+use Sinso\Webcomponents\DataProviding\Traits\Assert;
+use Sinso\Webcomponents\DataProviding\Traits\ContentObjectRendererTrait;
+use Sinso\Webcomponents\DataProviding\Traits\FileReferences;
+use Sinso\Webcomponents\Dto\ComponentRenderingData;
+use TYPO3\CMS\Core\Resource\FileReference;
+
+class Image implements ComponentInterface
+{
+    use Assert;
+    use ContentObjectRendererTrait;
+    use FileReferences;
+
+    public function provide(ComponentRenderingData $componentRenderingData): WebcomponentRenderingData
+    {
+        $record = $componentRenderingData->getContentRecord();
+        $image = $this->loadFileReference($record, 'image');
+
+        // rendering will stop here if no image is found
+        $this->assert($image instanceof FileReference, 'No image found for record ' . $record['uid']);
+
+        $componentRenderingData->setTagName('my-image');
+        $componentRenderingData->setTagProperties(['imageUrl' => $image->getPublicUrl()]);
+    }
+}
+```
 
 ## Render a web component in Fluid
 


### PR DESCRIPTION
Effectively the web component will still not render when not provided with a tag name, but the recommended way is to use the `Assert` trait.
Listeners for the ComponentWillBeRendered event can now also abort rendering by throwing an `\Sinso\Webcomponents\DataProviding\AssertionFailedException`.