### PR TITLE
feat!: pass InputData object to SubComponentRenderingHelper

### DIFF
--- a/Classes/ContentObject/WebcomponentContentObject.php
+++ b/Classes/ContentObject/WebcomponentContentObject.php
@@ -26,8 +26,7 @@ class WebcomponentContentObject extends AbstractContentObject
      */
     public function render($conf = []): string
     {
-        $inputData = GeneralUtility::makeInstance(
-            InputData::class,
+        $inputData = new InputData(
             $this->cObj?->data ?? [],
             $this->cObj?->getCurrentTable() ?? '',
         );

--- a/Classes/DataProviding/Helpers/SubComponentRenderingHelper.php
+++ b/Classes/DataProviding/Helpers/SubComponentRenderingHelper.php
@@ -21,19 +21,20 @@ class SubComponentRenderingHelper
 
     /**
      * @param class-string<ComponentInterface> $componentClassName
-     * @param array<string, mixed> $additionalInputData
      */
-    public function evaluateSubComponent(string $componentClassName, array $additionalInputData = [], ?string $slot = null): ?ComponentRenderingData
+    public function evaluateSubComponent(string $componentClassName, ?InputData $inputData = null, ?string $slot = null): ?ComponentRenderingData
     {
         $component = GeneralUtility::makeInstance($componentClassName);
         if (!$component instanceof ComponentInterface) {
             throw new \RuntimeException('Component must implement ComponentInterface');
         }
+        if ($inputData === null) {
+            $inputData = new InputData();
+        }
         /** @var ContentObjectRenderer $contentObjectRenderer */
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
-        $contentObjectRenderer->start([]);
+        $contentObjectRenderer->start($inputData->record, $inputData->tableName);
         $component->setContentObjectRenderer($contentObjectRenderer);
-        $inputData = GeneralUtility::makeInstance(InputData::class, [], '', $additionalInputData);
         try {
             $componentRenderingData = $component->provide($inputData);
         } catch (AssertionFailedException) {
@@ -49,11 +50,10 @@ class SubComponentRenderingHelper
 
     /**
      * @param class-string<ComponentInterface> $componentClassName
-     * @param array<string, mixed> $additionalInputData
      */
-    public function renderSubComponent(string $componentClassName, array $additionalInputData = [], ?string $slot = null): ?string
+    public function renderSubComponent(string $componentClassName, ?InputData $inputData = null, ?string $slot = null): ?string
     {
-        $componentRenderingData = $this->evaluateSubComponent($componentClassName, $additionalInputData, $slot);
+        $componentRenderingData = $this->evaluateSubComponent($componentClassName, $inputData, $slot);
         if ($componentRenderingData === null) {
             return null;
         }

--- a/Classes/Dto/InputData.php
+++ b/Classes/Dto/InputData.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sinso\Webcomponents\Dto;
 
-class InputData
+final class InputData
 {
     /**
      * @param array<string, string|integer> $record

--- a/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Classes/ViewHelpers/RenderViewHelper.php
@@ -43,7 +43,10 @@ class RenderViewHelper extends AbstractViewHelper
             $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
             $contentObjectRenderer->start([]);
         }
-        $inputData = GeneralUtility::makeInstance(InputData::class, $contentObjectRenderer->data, $contentObjectRenderer->getCurrentTable(), $arguments['inputData']);
+        /** @var ContentObjectRenderer $contentObjectRenderer */
+        /** @var array<string, mixed> $additionalData */
+        $additionalData = $arguments['inputData'];
+        $inputData = new InputData($contentObjectRenderer->data, $contentObjectRenderer->getCurrentTable(), $additionalData);
         /** @var class-string<ComponentInterface> $componentClassName */
         $componentClassName = $arguments['component'];
         try {


### PR DESCRIPTION
BREAKING CHANGE: renderSubComponent and evaluateSubComponent won't accept an $additionalData array anymore as 2nd parameter but need an InputData object (or null) instead.