### PR TITLE
chore!: make ComponentRenderingData final

### DIFF
--- a/Classes/Dto/ComponentRenderingData.php
+++ b/Classes/Dto/ComponentRenderingData.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sinso\Webcomponents\Dto;
 
-class ComponentRenderingData
+final class ComponentRenderingData
 {
     private ?string $tagContent = null;
     private ?string $tagName = null;


### PR DESCRIPTION
BREAKING CHANGE: You can't extend or mock ComponentRenderingData anymore