### PR TITLE
chore: switch arguments order for ComponentWillBeRendered constructor

### DIFF
--- a/Classes/ContentObject/WebcomponentContentObject.php
+++ b/Classes/ContentObject/WebcomponentContentObject.php
@@ -57,7 +57,7 @@ class WebcomponentContentObject extends AbstractContentObject
         }
         $componentRenderingData = $this->evaluateTypoScriptConfiguration($componentRenderingData, $conf);
 
-        $event = new ComponentWillBeRendered($contentObjectRenderer, $componentRenderingData);
+        $event = new ComponentWillBeRendered($componentRenderingData, $contentObjectRenderer);
         try {
             $this->eventDispatcher->dispatch($event);
             // render with tag builder

--- a/Classes/Dto/Events/ComponentWillBeRendered.php
+++ b/Classes/Dto/Events/ComponentWillBeRendered.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 final class ComponentWillBeRendered
 {
     public function __construct(
-        public readonly ContentObjectRenderer $contentObjectRenderer,
         public readonly ComponentRenderingData $componentRenderingData,
+        public readonly ContentObjectRenderer $contentObjectRenderer,
     ) {}
 }

--- a/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Classes/ViewHelpers/RenderViewHelper.php
@@ -55,7 +55,7 @@ class RenderViewHelper extends AbstractViewHelper
             return $e->getRenderingPlaceholder();
         }
 
-        $event = new ComponentWillBeRendered($contentObjectRenderer, $componentRenderingData);
+        $event = new ComponentWillBeRendered($componentRenderingData, $contentObjectRenderer);
         $eventDispatcher = GeneralUtility::makeInstance(EventDispatcher::class);
         $eventDispatcher->dispatch($event);
 


### PR DESCRIPTION
This is not considered breaking because it doesn't affect listeners for this event. Extension users are not expected to create this event.