### PR TITLE
feat: remove null values recursively

### DIFF
--- a/Classes/DataProviding/Helpers/ComponentRenderingHelper.php
+++ b/Classes/DataProviding/Helpers/ComponentRenderingHelper.php
@@ -22,18 +22,14 @@ class ComponentRenderingHelper
      */
     public function evaluateComponent(string $componentClassName, ?InputData $inputData = null, ?string $slot = null): ComponentRenderingData
     {
-        $component = GeneralUtility::makeInstance($componentClassName);
-        if (!$component instanceof ComponentInterface) {
-            throw new \RuntimeException('Component must implement ComponentInterface', 1729064021);
-        }
         if ($inputData === null) {
             $inputData = new InputData();
         }
         /** @var ContentObjectRenderer $contentObjectRenderer */
         $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
         $contentObjectRenderer->start($inputData->record, $inputData->tableName);
-        $component->setContentObjectRenderer($contentObjectRenderer);
-        $componentRenderingData = $component->provide($inputData);
+
+        $componentRenderingData = $this->componentRenderer->evaluateComponent($inputData, $componentClassName, $contentObjectRenderer);
 
         if ($slot !== null) {
             $componentRenderingData->setTagProperty('slot', $slot);

--- a/Classes/Rendering/ComponentRenderer.php
+++ b/Classes/Rendering/ComponentRenderer.php
@@ -11,6 +11,7 @@ use Sinso\Webcomponents\Dto\ComponentRenderingData;
 use Sinso\Webcomponents\Dto\Events\ComponentWillBeRendered;
 use Sinso\Webcomponents\Dto\InputData;
 use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
@@ -43,7 +44,11 @@ class ComponentRenderer
             $contentObjectRenderer->start([]);
         }
         $component->setContentObjectRenderer($contentObjectRenderer);
-        return $component->provide($inputData);
+        $componentRenderingData = $component->provide($inputData);
+        $componentRenderingData->setTagProperties(
+            ArrayUtility::removeNullValuesRecursive($componentRenderingData->getTagProperties())
+        );
+        return $componentRenderingData;
     }
 
     private function renderMarkup(ComponentRenderingData $componentRenderingData): string
@@ -59,9 +64,6 @@ class ComponentRenderer
             $tagBuilder->setContent($componentRenderingData->getTagContent());
         }
         foreach ($componentRenderingData->getTagProperties() as $key => $value) {
-            if ($value === null) {
-                continue;
-            }
             if (!is_scalar($value)) {
                 $value = json_encode($value);
             }


### PR DESCRIPTION
until now only top level null values were ignored from rendering the tag properties. now they are recursively removed.