### PR TITLE
chore: remove ContentObjectRenderer from interface

### DIFF
--- a/Classes/DataProviding/ComponentInterface.php
+++ b/Classes/DataProviding/ComponentInterface.php
@@ -9,6 +9,4 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 interface ComponentInterface
 {
     public function provide(InputData $inputData): ComponentRenderingData;
-
-    public function setContentObjectRenderer(ContentObjectRenderer $contentObjectRenderer): void;
 }

--- a/Classes/Rendering/ComponentRenderer.php
+++ b/Classes/Rendering/ComponentRenderer.php
@@ -44,7 +44,9 @@ class ComponentRenderer
             $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
             $contentObjectRenderer->start([]);
         }
-        $component->setContentObjectRenderer($contentObjectRenderer);
+        if (method_exists($component, 'setContentObjectRenderer')) {
+            $component->setContentObjectRenderer($contentObjectRenderer);
+        }
         $componentRenderingData = $component->provide($inputData);
         $componentRenderingData = $componentRenderingData->withTagProperties(
             ArrayUtility::removeNullValuesRecursive($componentRenderingData->getTagProperties())

--- a/README.md
+++ b/README.md
@@ -39,14 +39,11 @@ tt_content.tx_myext_mycontentelement.component = Acme\MyExt\Components\MyContent
 namespace Acme\MyExt\Components;
 
 use Sinso\Webcomponents\DataProviding\ComponentInterface;
-use Sinso\Webcomponents\DataProviding\Traits\ContentObjectRendererTrait;
 use Sinso\Webcomponents\Dto\ComponentRenderingData;
 use Sinso\Webcomponents\Dto\InputData;
 
 class MyContentElement implements ComponentInterface
 {
-    use ContentObjectRendererTrait;
-
     public function provide(InputData $inputData): ComponentRenderingData
     {
         $record = $inputData->record;
@@ -73,7 +70,6 @@ namespace Acme\MyExt\Components;
 
 use Sinso\Webcomponents\DataProviding\ComponentInterface;
 use Sinso\Webcomponents\DataProviding\Traits\Assert;
-use Sinso\Webcomponents\DataProviding\Traits\ContentObjectRendererTrait;
 use Sinso\Webcomponents\DataProviding\Traits\FileReferences;
 use Sinso\Webcomponents\Dto\ComponentRenderingData;
 use Sinso\Webcomponents\Dto\InputData;
@@ -82,7 +78,6 @@ use TYPO3\CMS\Core\Resource\FileReference;
 class Image implements ComponentInterface
 {
     use Assert;
-    use ContentObjectRendererTrait;
     use FileReferences;
 
     public function provide(InputData $inputData): ComponentRenderingData


### PR DESCRIPTION
You can still use the trait and will still get a cObj injected, but you don't have to anymore