### PR TITLE
feat: allow for some universal attributes on RenderViewHelper

### DIFF
--- a/Classes/Rendering/ComponentRenderer.php
+++ b/Classes/Rendering/ComponentRenderer.php
@@ -25,11 +25,11 @@ class ComponentRenderer
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {}
 
-    public function renderComponent(ComponentRenderingData $componentRenderingData, ContentObjectRenderer $contentObjectRenderer): string
+    public function renderComponent(ComponentRenderingData $componentRenderingData, ContentObjectRenderer $contentObjectRenderer, ?TagBuilder $tagBuilder = null): string
     {
         $event = new ComponentWillBeRendered($componentRenderingData, $contentObjectRenderer);
         $this->eventDispatcher->dispatch($event);
-        return $this->renderMarkup($event->getComponentRenderingData());
+        return $this->renderMarkup($event->getComponentRenderingData(), $tagBuilder);
     }
 
     /**
@@ -58,14 +58,15 @@ class ComponentRenderer
         return $event->getComponentRenderingData();
     }
 
-    private function renderMarkup(ComponentRenderingData $componentRenderingData): string
+    private function renderMarkup(ComponentRenderingData $componentRenderingData, ?TagBuilder $tagBuilder = null): string
     {
         if ($componentRenderingData->getTagName() === null) {
             throw new AssertionFailedException('No tag name provided', 1730800497);
         }
 
-        /** @var TagBuilder $tagBuilder */
-        $tagBuilder = GeneralUtility::makeInstance(TagBuilder::class);
+        if ($tagBuilder === null) {
+            $tagBuilder = GeneralUtility::makeInstance(TagBuilder::class);
+        }
         $tagBuilder->setTagName($componentRenderingData->getTagName());
         if (!empty($componentRenderingData->getTagContent())) {
             $tagBuilder->setContent($componentRenderingData->getTagContent());

--- a/Classes/ViewHelpers/RenderViewHelper.php
+++ b/Classes/ViewHelpers/RenderViewHelper.php
@@ -11,14 +11,16 @@ use Sinso\Webcomponents\Rendering\ComponentRenderer;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
-class RenderViewHelper extends AbstractViewHelper
+class RenderViewHelper extends AbstractTagBasedViewHelper
 {
     protected $escapeOutput = false;
 
     public function initializeArguments(): void
     {
+        $this->registerUniversalTagAttributes();
+
         $this->registerArgument('component', 'string', 'Class name', true);
         $this->registerArgument('inputData', 'array', 'input data', false, []);
         $this->registerArgument('contentObjectRenderer', ContentObjectRenderer::class, 'current cObj');
@@ -43,7 +45,7 @@ class RenderViewHelper extends AbstractViewHelper
             return $e->getRenderingPlaceholder();
         }
 
-        return $componentRenderer->renderComponent($componentRenderingData, $contentObjectRenderer);
+        return $componentRenderer->renderComponent($componentRenderingData, $contentObjectRenderer, $this->tag);
     }
 
     protected function getContentObjectRenderer(): ContentObjectRenderer


### PR DESCRIPTION
allows for class, dir, id, lang, style, title, accesskey, tabindex and onclick attributes to be directly used on the render view helper

```html
<wc:render component="MyVendor\MyExt\Components\MyComponent" title="This title will be applied to the rendered web component tag"/>
```