### PR TITLE
!chore: remove deprecated methods from ComponentRenderingData

### DIFF
--- a/Classes/Dto/ComponentRenderingData.php
+++ b/Classes/Dto/ComponentRenderingData.php
@@ -18,15 +18,6 @@ final class ComponentRenderingData
         return $this->tagContent;
     }
 
-    /**
-     * @deprecated Use withTagContent() instead.
-     */
-    public function setTagContent(?string $tagContent): void
-    {
-        trigger_error('Setting tag content is deprecated. Use withTagContent() instead.', E_USER_DEPRECATED);
-        $this->tagContent = $tagContent;
-    }
-
     public function withTagContent(?string $tagContent): self
     {
         $clonedObject = clone $this;
@@ -42,31 +33,11 @@ final class ComponentRenderingData
         return $this->tagProperties;
     }
 
-    /**
-     * @deprecated Use withTagProperty() instead.
-     */
-    public function setTagProperty(string $key, mixed $value): void
-    {
-        trigger_error('Setting tag property is deprecated. Use withTagProperty() instead.', E_USER_DEPRECATED);
-        $this->tagProperties[$key] = $value;
-    }
-
     public function withTagProperty(string $key, mixed $value): self
     {
         $clonedObject = clone $this;
         $clonedObject->tagProperties[$key] = $value;
         return $clonedObject;
-    }
-
-    /**
-     * @deprecated Use withTagProperties() instead.
-     *
-     * @param array<string, mixed> $tagProperties
-     */
-    public function setTagProperties(array $tagProperties): void
-    {
-        trigger_error('Setting tag properties is deprecated. Use withTagProperties() instead.', E_USER_DEPRECATED);
-        $this->tagProperties = $tagProperties;
     }
 
     /**
@@ -82,15 +53,6 @@ final class ComponentRenderingData
     public function getTagName(): ?string
     {
         return $this->tagName;
-    }
-
-    /**
-     * @deprecated Use withTagName() instead.
-     */
-    public function setTagName(string $tagName): void
-    {
-        trigger_error('Setting tag name is deprecated. Use withTagName() instead.', E_USER_DEPRECATED);
-        $this->tagName = $tagName;
     }
 
     public function withTagName(string $tagName): self

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ class MyContentElement implements ComponentInterface
         ];
 
         return (new ComponentRenderingData())
-            ->withTagName('my-web-component')
-            ->withTagProperties($properties);
+            ->withTagProperties($properties)
+            ->withTagName('my-web-component');
     }
 }
 ```
@@ -69,8 +69,8 @@ The component classes can use the `\Sinso\Webcomponents\DataProviding\Traits\Ass
 namespace Acme\MyExt\Components;
 
 use Sinso\Webcomponents\DataProviding\ComponentInterface;
+use Sinso\Webcomponents\DataProviding\Helpers\FileReferencesHelper;
 use Sinso\Webcomponents\DataProviding\Traits\Assert;
-use Sinso\Webcomponents\DataProviding\Traits\FileReferences;
 use Sinso\Webcomponents\Dto\ComponentRenderingData;
 use Sinso\Webcomponents\Dto\InputData;
 use TYPO3\CMS\Core\Resource\FileReference;
@@ -78,19 +78,22 @@ use TYPO3\CMS\Core\Resource\FileReference;
 class Image implements ComponentInterface
 {
     use Assert;
-    use FileReferences;
+
+    public function __construct(
+        private readonly FileReferencesHelper $fileReferencesHelper,
+    ) {}
 
     public function provide(InputData $inputData): ComponentRenderingData
     {
         $record = $inputData->record;
-        $image = $this->loadFileReference($record, 'image');
+        $image = $this->fileReferencesHelper->loadFileReference($record, 'image');
 
         // rendering will stop here if no image is found
         $this->assert($image instanceof FileReference, 'No image found for record ' . $record['uid']);
 
         return (new ComponentRenderingData())
-            ->withTagName('my-image')
-            ->withTagProperties(['imageUrl' => $image->getPublicUrl()]);
+            ->withTagProperty('imageUrl', $image->getPublicUrl())
+            ->withTagName('my-image');
     }
 }
 ```
@@ -104,7 +107,7 @@ class Image implements ComponentInterface
 >
 
 <wc:render
-    component="Acme\\MyExt\\Components\\LocationOverview"
+    component="Acme\MyExt\Components\LocationOverview"
     inputData="{'header': 'This is the header'}"
 />
 


### PR DESCRIPTION
Use ComponentRenderingData like this

```php
return (new ComponentRenderingData())
    ->withTagProperties($properties)
    ->withTagContent($content)
    ->withTagName('my-component');
```

BREAKING CHANGE: ->setTagContent(), ->setTagProperty(), ->setTagProperties(), ->setTagName have been removed. Always use the pattern shown above.