### PR TITLE
chore: add phpstan annotation to assert

### DIFF
--- a/Classes/DataProviding/Traits/Assert.php
+++ b/Classes/DataProviding/Traits/Assert.php
@@ -10,6 +10,9 @@ use Sinso\Webcomponents\DataProviding\AssertionFailedException;
  */
 trait Assert
 {
+    /**
+     * @phpstan-assert true $condition
+     */
     protected function assert(bool $condition, string $message): void
     {
         if ($condition) {


### PR DESCRIPTION
this makes phpstan actually understand the consequence of the assert function, so it can infer type annotations for example